### PR TITLE
Forcefully use IPv4 to prevent hanging requests

### DIFF
--- a/domain.py
+++ b/domain.py
@@ -1,6 +1,7 @@
 import json
 import requests
 import logging
+requests.packages.urllib3.util.connection.HAS_IPV6 = False
 
 UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/117.0'
 

--- a/piehtvn.py
+++ b/piehtvn.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from domain import Domain
 
 import requests
+requests.packages.urllib3.util.connection.HAS_IPV6 = False
+
 import six
 from bs4 import BeautifulSoup
 


### PR DESCRIPTION
This method sets the `requests` module to use IPv4 only, which will prevent requests from hanging and timing out:

![Screen Shot 2024-10-17 at 08 36 01](https://github.com/user-attachments/assets/d31abdea-3a5e-497b-afed-eaf6c7b4b294)

Seems like something is being funny at ISP-level, IPv6 only. I have tried all 3 major providers.

![Screen Shot 2024-10-17 at 08 38 01](https://github.com/user-attachments/assets/4606db61-517e-41f0-8821-022fe9728e28)

By setting `HAS_IPV6` flag in `requests` lib initialization to `False`, this will be resolved.